### PR TITLE
Refactor Command Class architecture: Parse pattern, solicited/unsolicited split, and validation

### DIFF
--- a/src/ZWave.BuildTools/CommandClassFactoryGenerator.cs
+++ b/src/ZWave.BuildTools/CommandClassFactoryGenerator.cs
@@ -97,17 +97,19 @@ internal sealed class CommandClassAttribute: Attribute
         sb.Append(@"
 #nullable enable
 
+using Microsoft.Extensions.Logging;
+
 namespace ZWave.CommandClasses;
 
 internal static class CommandClassFactory
 {
-    private static readonly Dictionary<CommandClassId, Func<CommandClassInfo, IDriver, INode, CommandClass>> Constructors = new Dictionary<CommandClassId, Func<CommandClassInfo, IDriver, INode, CommandClass>>
+    private static readonly Dictionary<CommandClassId, Func<CommandClassInfo, IDriver, INode, ILogger, CommandClass>> Constructors = new Dictionary<CommandClassId, Func<CommandClassInfo, IDriver, INode, ILogger, CommandClass>>
     {
 ");
 
         foreach (KeyValuePair<string, string> pair in idToType)
         {
-            sb.AppendLine($"        {{ {pair.Key}, (info, driver, node) => new {pair.Value}(info, driver, node) }},");
+            sb.AppendLine($"        {{ {pair.Key}, (info, driver, node, logger) => new {pair.Value}(info, driver, node, logger) }},");
         }
 
         sb.Append(@"    };
@@ -123,10 +125,10 @@ internal static class CommandClassFactory
 
         sb.Append(@"    };
 
-    public static CommandClass Create(CommandClassInfo info, IDriver driver, INode node)
-        => Constructors.TryGetValue(info.CommandClass, out Func<CommandClassInfo, IDriver, INode, CommandClass>? constructor)
-            ? constructor(info, driver, node)
-            : new NotImplementedCommandClass(info, driver, node);
+    public static CommandClass Create(CommandClassInfo info, IDriver driver, INode node, ILogger logger)
+        => Constructors.TryGetValue(info.CommandClass, out Func<CommandClassInfo, IDriver, INode, ILogger, CommandClass>? constructor)
+            ? constructor(info, driver, node, logger)
+            : new NotImplementedCommandClass(info, driver, node, logger);
 
     public static CommandClassId GetCommandClassId<TCommandClass>()
         where TCommandClass : CommandClass

--- a/src/ZWave.CommandClasses/NotImplementedCommandClass.cs
+++ b/src/ZWave.CommandClasses/NotImplementedCommandClass.cs
@@ -1,4 +1,6 @@
-﻿namespace ZWave.CommandClasses;
+using Microsoft.Extensions.Logging;
+
+namespace ZWave.CommandClasses;
 
 /// <summary>
 /// Placeholder command enum for command classes that have not been implemented.
@@ -12,7 +14,7 @@ public enum NotImplementedCommand : byte
 /// </summary>
 public sealed class NotImplementedCommandClass : CommandClass<NotImplementedCommand>
 {
-    internal NotImplementedCommandClass(CommandClassInfo info, IDriver driver, INode node) : base(info, driver, node)
+    internal NotImplementedCommandClass(CommandClassInfo info, IDriver driver, INode node, ILogger logger) : base(info, driver, node, logger)
     {
     }
 
@@ -21,7 +23,7 @@ public sealed class NotImplementedCommandClass : CommandClass<NotImplementedComm
 
     internal override Task InterviewAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
-    protected override void ProcessCommandCore(CommandClassFrame frame)
+    protected override void ProcessUnsolicitedCommand(CommandClassFrame frame)
     {
     }
 }

--- a/src/ZWave.Protocol/ZWaveErrorCode.cs
+++ b/src/ZWave.Protocol/ZWaveErrorCode.cs
@@ -44,4 +44,9 @@ public enum ZWaveErrorCode
     /// The command was called with an invalid argument.
     /// </summary>
     CommandInvalidArgument,
+
+    /// <summary>
+    /// A received command frame had an invalid or malformed payload.
+    /// </summary>
+    InvalidPayload,
 }

--- a/src/ZWave.Server/CommandClasses/Battery.razor
+++ b/src/ZWave.Server/CommandClasses/Battery.razor
@@ -7,9 +7,9 @@
 @if (CommandClass != null)
 {
     <table class="table table-striped">
-        @if (CommandClass.State.HasValue)
+        @if (CommandClass.LastReport.HasValue)
         {
-            var state = CommandClass.State.Value;
+            var state = CommandClass.LastReport.Value;
 
             <tbody>
                 <tr>
@@ -86,9 +86,9 @@
             </tbody>
         }
 
-        @if (CommandClass.Health.HasValue)
+        @if (CommandClass.LastHealthReport.HasValue)
         {
-            var health = CommandClass.Health.Value;
+            var health = CommandClass.LastHealthReport.Value;
 
             <tbody>
                 <tr>

--- a/src/ZWave.Server/CommandClasses/BinarySwitch.razor
+++ b/src/ZWave.Server/CommandClasses/BinarySwitch.razor
@@ -7,29 +7,29 @@
 @if (CommandClass != null)
 {
     <table class="table table-striped">
-        @if (CommandClass.State.HasValue)
+        @if (CommandClass.LastReport.HasValue)
         {
-            BinarySwitchState state = CommandClass.State.Value;
+            BinarySwitchReport report = CommandClass.LastReport.Value;
 
             <tbody>
                 <tr>
                     <th scope="row">Current Value</th>
-                    <td>@(state.CurrentValue.HasValue ? state.CurrentValue.Value : "Unknown")</td>
+                    <td>@(report.CurrentValue.HasValue ? report.CurrentValue.Value : "Unknown")</td>
                 </tr>
 
-                @if (state.TargetValue.HasValue)
+                @if (report.TargetValue.HasValue)
                 {
                     <tr>
                         <th scope="row">Target Value</th>
-                        <td>@state.TargetValue.Value</td>
+                        <td>@report.TargetValue.Value</td>
                     </tr>
                 }
 
-                @if (state.Duration.HasValue)
+                @if (report.Duration.HasValue)
                 {
                     <tr>
                         <th scope="row">Duration</th>
-                        <td>@(state.Duration.Value.Duration?.ToString("c") ?? "Unknown")</td>
+                        <td>@(report.Duration.Value.Duration?.ToString("c") ?? "Unknown")</td>
                     </tr>
                 }
             </tbody>

--- a/src/ZWave.Server/CommandClasses/MultilevelSwitch.razor
+++ b/src/ZWave.Server/CommandClasses/MultilevelSwitch.razor
@@ -8,28 +8,28 @@
 {
     <table class="table table-striped">
         <tbody>
-            @if (CommandClass.State.HasValue)
+            @if (CommandClass.LastReport.HasValue)
             {
-                MultilevelSwitchState state = CommandClass.State.Value;
+                MultilevelSwitchReport report = CommandClass.LastReport.Value;
 
                 <tr>
                     <th scope="row">Current Value</th>
-                    <td>@state.CurrentValue.Value</td>
+                    <td>@report.CurrentValue.Value</td>
                 </tr>
 
-                @if (state.TargetValue.HasValue)
+                @if (report.TargetValue.HasValue)
                 {
                     <tr>
                         <th scope="row">Target Value</th>
-                        <td>@state.TargetValue.Value</td>
+                        <td>@report.TargetValue.Value</td>
                     </tr>
                 }
 
-                @if (state.Duration.HasValue)
+                @if (report.Duration.HasValue)
                 {
                     <tr>
                         <th scope="row">Duration</th>
-                        <td>@(state.Duration.Value.Duration?.ToString("c") ?? "Unknown")</td>
+                        <td>@(report.Duration.Value.Duration?.ToString("c") ?? "Unknown")</td>
                     </tr>
                 }
             }

--- a/src/ZWave.Server/CommandClasses/Powerlevel.razor
+++ b/src/ZWave.Server/CommandClasses/Powerlevel.razor
@@ -9,9 +9,9 @@
 @if (CommandClass != null)
 {
     <table class="table table-striped">
-        @if (CommandClass.State.HasValue)
-        {
-            PowerlevelState state = CommandClass.State.Value;
+        @if (CommandClass.LastReport.HasValue)
+    {
+            PowerlevelReport report = CommandClass.LastReport.Value;
 
             <tbody>
                 <tr>
@@ -19,14 +19,14 @@
                 </tr>
                 <tr>
                     <th scope="row">Power Level</th>
-                    <td>@state.Powerlevel</td>
+                    <td>@report.Powerlevel</td>
                 </tr>
 
-                @if (state.TimeoutInSeconds.HasValue)
+                @if (report.TimeoutInSeconds.HasValue)
                 {
                     <tr>
                         <th scope="row">Timeout in Seconds</th>
-                        <td>@state.TimeoutInSeconds.Value</td>
+                        <td>@report.TimeoutInSeconds.Value</td>
                     </tr>
                 }
             </tbody>

--- a/src/ZWave.Server/CommandClasses/WakeUp.razor
+++ b/src/ZWave.Server/CommandClasses/WakeUp.razor
@@ -9,9 +9,9 @@
 @if (CommandClass != null)
 {
     <table class="table table-striped">
-        @if (CommandClass.Interval != null)
+        @if (CommandClass.LastInterval != null)
         {
-            WakeUpInterval wakeUpInterval = CommandClass.Interval.Value;
+            WakeUpInterval wakeUpInterval = CommandClass.LastInterval.Value;
 
             <tbody>
                 <tr>

--- a/src/ZWave/Node.cs
+++ b/src/ZWave/Node.cs
@@ -275,7 +275,7 @@ public sealed class Node : INode
                     }
                     else
                     {
-                        CommandClass commandClass = CommandClassFactory.Create(commandClassInfo, _driver, this);
+                        CommandClass commandClass = CommandClassFactory.Create(commandClassInfo, _driver, this, _logger);
                         newDict.Add(commandClassInfo.CommandClass, commandClass);
                     }
                 }


### PR DESCRIPTION
## Summary

Major refactoring of all existing Command Class implementations to establish a consistent, maintainable pattern for parsing reports, handling solicited vs. unsolicited frames, and validating payloads.

## Key Changes

### Architecture

- Solicited/unsolicited report split: `ProcessCommand` in the base class now checks awaiters first. Solicited reports (responses to `Get` commands) are parsed directly in `GetAsync`;
`ProcessUnsolicitedCommand` is only called for unsolicited reports. This eliminates double-parsing.
- Static Parse methods: Report commands now have a static `Parse(CommandClassFrame, ILogger)` method instead of instance properties. Parse validates, logs, and throws on malformed frames.
- `ILogger` threading: Added `ILogger` to `CommandClass` constructor, threaded through the source-generated `CommandClassFactory` and `Node`.

### Validation & Error Handling

- Parse methods validate payload length (including multi-stage validation for variable-length fields) and throw `ZWaveException(ZWaveErrorCode.InvalidPayload, ...)` on failure.
- Added `InvalidPayload` to `ZWaveErrorCode` enum.
- Unsolicited exceptions are caught by the base class (Parse already logged). Solicited exceptions propagate to callers.

### Type Simplification

- Report data types converted from `public readonly struct` with manual constructors to `public readonly record struct` with positional parameters.
- Renamed State → LastReport, Health → LastHealthReport, Interval → LastInterval for naming consistency across all CCs.

### Bug Fixes

- `MultilevelSwitchCommandClass`: `GetSupportedAsync` awaited the wrong report type (`ReportCommand` instead of `SupportedReportCommand`), which would `NullReferenceException` at runtime.
- `BatteryHealthReportCommand`: Missing bounds check before slicing by `valueSize`.
- `PowerlevelReportCommand`: Accessed `Span[1]` without bounds check.
- `PowerlevelTestNodeReportCommand`: Accessed `Span[1..4]` with only `Length >= 1` validated.
- `MultilevelSensorCommandClass`: Missing `valueSize` vs remaining frame length validation.
- Predicate safety: Predicates in `AwaitNextReportAsync` now use direct byte access instead of calling Parse, preventing spurious log warnings and double-parsing.
- Removed forward-compatibility violations (`_version >= 2` checks replaced with payload-length checks).
- Missing `.ConfigureAwait(false)` in `MultilevelSwitchCommandClass.InterviewAsync`.